### PR TITLE
Feature/start style

### DIFF
--- a/src/Components/StartPage/style.ts
+++ b/src/Components/StartPage/style.ts
@@ -7,10 +7,7 @@ export const StartPage = styled.div`
 `;
 
 export const LeftBox = styled.div`
-  margin: 27vh 0 0 5vw;
-  @media only screen and (max-width: 1700px) {
-    margin: 20vh 56px 0 5vw;
-  }
+  margin: 20vh 0 0 5vw;
   @media ${device.tablet} {
     padding: 24px;
     margin: 48px auto;
@@ -36,6 +33,13 @@ export const Logo = styled.div`
   svg {
     width: 346px;
     height: 80px;
+    @media screen and (max-width: 1300px) {
+      width: 300px;
+    }
+    @media ${device.tablet} {
+      width: 270px;
+      margin: 0 auto;
+    }
     @media ${device.mobile} {
       width: 250px;
       margin: 0 auto;
@@ -118,6 +122,7 @@ export const ImgBox = styled.div`
   }
   & svg:nth-child(1) {
     animation: ${slide} 10s infinite linear alternate;
+    margin: 0;
   }
   & svg:nth-child(2) {
     animation: ${slide} 10s infinite linear alternate-reverse;
@@ -127,11 +132,10 @@ export const ImgBox = styled.div`
   }
   & svg:nth-child(4) {
     animation: ${slide} 10s infinite linear alternate-reverse;
-    margin: 0;
   }
   svg {
     display: block;
-    float: left;
+    float: right;
     margin-right: 1.25vw;
   }
 `;

--- a/src/Components/StartPage/style.ts
+++ b/src/Components/StartPage/style.ts
@@ -7,7 +7,10 @@ export const StartPage = styled.div`
 `;
 
 export const LeftBox = styled.div`
-  margin: 261px 56px 0 5vw;
+  margin: 27vh 0 0 5vw;
+  @media only screen and (max-width: 1700px) {
+    margin: 20vh 56px 0 5vw;
+  }
   @media ${device.tablet} {
     padding: 24px;
     margin: 48px auto;
@@ -22,7 +25,7 @@ export const StartHeader = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: 25.5vh;
-  color: #6A76E9;
+  color: #6a76e9;
 `;
 
 export const Logo = styled.div`
@@ -33,10 +36,6 @@ export const Logo = styled.div`
   svg {
     width: 346px;
     height: 80px;
-    /* @media ${device.laptop} {
-
-        max-width: 300px;
-    } */
     @media ${device.mobile} {
       width: 250px;
       margin: 0 auto;
@@ -67,13 +66,12 @@ export const ButtonBox = styled.div`
 
   @media ${device.tablet} {
     flex-direction: column;
-
   }
 
   button {
     width: 190px;
     padding: 21px 0;
-    background-color: #6A76E9;
+    background-color: #6a76e9;
     color: #ffffff;
     border-radius: 12px;
     outline: 0;
@@ -81,7 +79,7 @@ export const ButtonBox = styled.div`
     font-weight: 600;
     font-size: 24px;
     margin-right: 30px;
-    
+
     @media ${device.tablet} {
       width: 100%;
       margin: 0;
@@ -129,10 +127,11 @@ export const ImgBox = styled.div`
   }
   & svg:nth-child(4) {
     animation: ${slide} 10s infinite linear alternate-reverse;
+    margin: 0;
   }
   svg {
     display: block;
     float: left;
-    margin-right: 24px;
+    margin-right: 1.25vw;
   }
 `;


### PR DESCRIPTION
## 개요

1. startPage를 배율125%로 보면 반응형 오류가 생깁니다.

![image](https://user-images.githubusercontent.com/80191860/141304553-e3e06a2a-67a8-4d29-b706-ec0a5d95ec87.png)

2. 요소가 겹치면 오른쪽 슬라이드 박스부터 없어집니다.

![image](https://user-images.githubusercontent.com/80191860/141304653-0f2a6575-1387-4f94-9e6d-2306125f37f8.png)


## 작업사항

1. left box의 전체적인 margin의 수치를 줄였습니다.
2. `float : left`를 `float : right`로 변경하였습니다.
3. logo 반응형 추가하였습니다. ( width 조절 )
> 1번에서 margin 수치를 줄이는 방법 말고 더 좋은 방안이 있으면 알려주세요..!!


## 수정 후

> margin을 조정하여 배율이 125%일때 y축 스크롤이 안생기게 하였습니다.

![image](https://user-images.githubusercontent.com/80191860/141305121-f5f3239e-f4c4-40ed-906e-529594cf51a5.png)


> 가장 가까운 슬라이드 박스가 없어지게 하였습니다.

![image](https://user-images.githubusercontent.com/80191860/141304840-90d5d48e-180f-486d-b04b-3d726fe3be59.png)



